### PR TITLE
fix: worked on responsiveness

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6,6 +6,20 @@ body {
   font-family: Arial, Helvetica, sans-serif;
 }
 
+.scrollbar-force::-webkit-scrollbar {
+  height: 6px;
+}
+
+.scrollbar-force::-webkit-scrollbar-thumb {
+  background-color: #f97316; /* orange-500 */
+  border-radius: 9999px;
+}
+
+.scrollbar-force::-webkit-scrollbar-track {
+  background-color: #f3f4f6; /* gray-100 */
+  border-radius: 9999px;
+}
+
 @layer utilities {
   .text-balance {
     text-wrap: balance;

--- a/app/landing/page.tsx
+++ b/app/landing/page.tsx
@@ -181,9 +181,9 @@ const LandingPage = () => {
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ delay: 0.6 }}
-            className="flex flex-col sm:flex-row gap-4 justify-center items-center"
+            className="flex flex-col sm:flex-row gap-4 justify-center items-center "
           >
-            <div className="flex items-center bg-gray-900 rounded-lg border border-gray-700 overflow-hidden">
+            <div className="flex items-center bg-gray-900 rounded-lg border border-gray-700 overflow-hidden w-11/12 md:w-auto">
               <input
                 type="text"
                 placeholder={CLONE_PORTFOLIO_COMMAND}
@@ -454,7 +454,7 @@ const LandingPage = () => {
           </p>
         </motion.div>
 
-        <div className="grid md:grid-cols-3 gap-8">
+        <div className="grid md:grid-cols-3 gap-8 items-center justify-center">
           {[
             {
               step: "1",
@@ -478,7 +478,7 @@ const LandingPage = () => {
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               transition={{ delay: index * 0.1 }}
-              className="bg-gray-900/50 border border-gray-800 rounded-xl p-6"
+              className="bg-gray-900/50 border border-gray-800 rounded-xl p-6 h-[200px] w-[350px] md:w-auto"
             >
               <div className="flex items-center space-x-3 mb-4">
                 <div className="w-8 h-8 bg-orange-500 text-white rounded-full flex items-center justify-center font-bold text-sm">
@@ -486,8 +486,8 @@ const LandingPage = () => {
                 </div>
                 <h3 className="text-lg font-semibold">{item.title}</h3>
               </div>
-              <div className="bg-black rounded-lg p-4 font-mono text-sm text-gray-300 overflow-x-auto">
-                <pre>{item.code}</pre>
+              <div className="bg-black rounded-lg p-4 font-mono text-sm text-gray-300 overflow-x-auto  [&::-webkit-scrollbar]:h-2 [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-track]:bg-gray-100 [&::-webkit-scrollbar-thumb]:bg-orange-500 [&::-webkit-scrollbar-thumb]:rounded-full ">
+                <pre className="">{item.code}</pre>
               </div>
             </motion.div>
           ))}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,22 +7,22 @@ import ShadowLayout from "../templates/shadow/page";
 import LandingPage from "./landing/page";
 
 export default function Home() {
-  // Check if we're in demo mode (environment variable or query parameter)
-  const isDemoMode = process.env.NEXT_PUBLIC_DEMO_MODE === "true";
+  // // Check if we're in demo mode (environment variable or query parameter)
+  // const isDemoMode = process.env.NEXT_PUBLIC_DEMO_MODE === "true";
 
-  // If demo mode is disabled, show the configured user template
-  if (!isDemoMode) {
-    switch (AppSettingData.template) {
-      case AVAILABLE_TEMPLATES.BASE:
-        return <BaseTemplate />;
-      case AVAILABLE_TEMPLATES.NEON:
-        return <NeonTemplate />;
-      case AVAILABLE_TEMPLATES.SHADOW:
-        return <ShadowLayout />;
-      default:
-        return <BaseTemplate />;
-    }
-  }
+  // // If demo mode is disabled, show the configured user template
+  // if (!isDemoMode) {
+  //   switch (AppSettingData.template) {
+  //     case AVAILABLE_TEMPLATES.BASE:
+  //       return <BaseTemplate />;
+  //     case AVAILABLE_TEMPLATES.NEON:
+  //       return <NeonTemplate />;
+  //     case AVAILABLE_TEMPLATES.SHADOW:
+  //       return <ShadowLayout />;
+  //     default:
+  //       return <BaseTemplate />;
+  //   }
+  // }
 
   // Default to landing page in demo mode
   return <LandingPage />;


### PR DESCRIPTION
## What does this PR do?
When i visited the site, i realized the repo link and the get started section cards weren't showing well on mobile. So this pr fixes the responsiveness of the github repo link on the herosection and that of the get started section cards.

## Checklist of what you did
- [x] Fixed the responsivenes of the repo link by giving it a percentage width
- [x] Styled the scrollbar on get started section cards, gave the cards a fixed width on mobile view, and an automatic width on desktop.

## Design
before:

![Screenshot From 2025-07-09 13-50-14](https://github.com/user-attachments/assets/9ef67375-2e94-46c1-81cc-22f9b68bf62d)

![Screenshot From 2025-07-09 13-50-44](https://github.com/user-attachments/assets/cb76027f-037c-403c-9abc-eebf6090054a)

![Screenshot From 2025-07-09 14-58-00](https://github.com/user-attachments/assets/899ac848-71db-404e-ae61-71bc99b455b7)


After:

![Screenshot From 2025-07-09 15-19-35](https://github.com/user-attachments/assets/950290cb-3734-4982-950a-96d012795a9c)

![Screenshot From 2025-07-09 15-19-49](https://github.com/user-attachments/assets/a1ed6907-641e-4231-8af3-503f038d0926)

![Screenshot From 2025-07-09 14-57-27](https://github.com/user-attachments/assets/d5cf7217-f546-45e7-8507-89295b8dffa4)
